### PR TITLE
[master] removed content type header

### DIFF
--- a/lib/opencpu/client.rb
+++ b/lib/opencpu/client.rb
@@ -31,7 +31,6 @@ module OpenCPU
       return fake_response_for(url) if OpenCPU.test_mode?
       options   = {
         body: data,
-        headers: {"Content-Type" => 'application/json'},
         verify: false
       }
 


### PR DESCRIPTION
I suggest to remove the JSON header, because, in the current version, executing code snippets like in the following is not possible:

```
curl -d 'x=data.frame(x=1,y=1)' https://public.opencpu.org/ocpu/library/base/R/identity
```

It is not allowed to submit non-JSON values for arguments (here: for 'x'). But one needs to pass a verbatim R expression for arbitrary code execution. See for example [this fiddle](http://jsfiddle.net/opencpu/v42v3/).
