### PR TITLE
add option to call package from github repository

### DIFF
--- a/lib/opencpu/client.rb
+++ b/lib/opencpu/client.rb
@@ -11,7 +11,8 @@ module OpenCPU
       user   = options.fetch :user, :system
       data   = options.fetch :data, {}
       format = options.fetch :format, :json
-      process_query package_url(package, function, user, :json), data, format do |response|
+      github_remote = options.fetch :github_remote, false
+      process_query package_url(package, function, user, github_remote, :json), data, format do |response|
         JSON.parse(response.body)
       end
     end
@@ -20,7 +21,8 @@ module OpenCPU
       user = options.fetch :user, :system
       data = options.fetch :data, {}
       format = options.fetch :format, :json
-      process_query package_url(package, function, user), data, format do |response|
+      github_remote = options.fetch :github_remote, false
+      process_query package_url(package, function, user, github_remote), data, format do |response|
         location  = response.headers['location']
         resources = response.body.split(/\n/)
         OpenCPU::DelayedCalculation.new(location, resources)
@@ -65,8 +67,9 @@ module OpenCPU
       options
     end
 
-    def package_url(package, function, user = :system, format = nil)
+    def package_url(package, function, user = :system, github_remote = false, format = nil)
       return ['', 'library', package, 'R', function, format.to_s].join('/') if user == :system
+      return ['', 'github', user, package, 'R', function, format.to_s].join('/') if github_remote
       return ['', 'user', user, 'library', package, 'R', function, format.to_s].join('/')
     end
 

--- a/spec/lib/opencpu/client_spec.rb
+++ b/spec/lib/opencpu/client_spec.rb
@@ -139,6 +139,38 @@ describe OpenCPU::Client do
       end
     end
 
+    context 'GitHub package' do
+      before do
+        OpenCPU.configure do |config|
+          config.endpoint_url = 'https://staging.opencpu.roqua.nl/ocpu'
+          config.username     = 'foo'
+          config.password     = 'bar'
+          config.timeout      = 123
+        end
+      end
+      after { OpenCPU.reset_configuration! }
+      let(:client) { described_class.new }
+ 
+      it "can access github packages" do
+        VCR.use_cassette :github_plyr_mapvalues do
+          response = client.execute(:plyr, :mapvalues, {user: "hadley", github_remote: true, data: { "x" => ['a', 'b', 'c'], "from" => ['a', 'c'] , "to" => ['A', 'C'] }})
+          expect(response).to eq ["A", "b", "C"]
+        end
+      end
+ 
+      it "what happens when package is not available on GitHub" do
+        VCR.use_cassette :github_plyr_mapvalues do
+          exception_message = nil
+          begin
+            response = client.execute(:foobar, :mapvalues, {user: "hadley", github_remote: true, data: { "x" => ['a', 'b', 'c'], "from" => ['a', 'c'] , "to" => ['A', 'C'] }})
+          rescue Exception => ex
+            exception_message = ex.message
+          end
+          expect(exception_messagestart_with?('400: Bad Request'))
+        end
+      end
+    end
+
     context 'when in test mode' do
       it 'has an empty fake response when just enabled' do
         OpenCPU.enable_test_mode!


### PR DESCRIPTION
Added support to call packages via the GitHub interface of OpenCPU. When github_remote option is set, the username is interpreted as a GitHub user and the corresponding package is called.